### PR TITLE
loader-utils dependencies version up

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/richardscarrott/require-error-handler-webpack-plugin",
   "dependencies": {
-    "loader-utils": "^0.2.6",
+    "loader-utils": "^1.1.0",
     "webpack": "^1.5.3"
   }
 }

--- a/src/BundleLoader.js
+++ b/src/BundleLoader.js
@@ -9,7 +9,7 @@ var loaderUtils = require("loader-utils");
 module.exports = function() {};
 module.exports.pitch = function(remainingRequest) {
 	this.cacheable && this.cacheable();
-	var query = loaderUtils.parseQuery(this.query);
+	var query = loaderUtils.getOptions(this) || {};
 	if(query.name) {
 		var options = {
 			context: query.context || this.options.context,


### PR DESCRIPTION
loaderUtils.parseQuery will be remove 
so 'loaderUtils.parseQuery' change to 'loaderUtils.getOptions'
```
(node:68193) DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56
parseQuery() will be replaced with getOptions() in the next major version of loader-utils.
```
